### PR TITLE
Fix enterprise governance delta checks

### DIFF
--- a/docs/engineering/pipeline-overview.md
+++ b/docs/engineering/pipeline-overview.md
@@ -74,6 +74,13 @@ Efeito:
 4. `build-and-check` e `security-and-compliance` so rodam quando `release_eligible=true`.
 5. O job `trigger-release` so roda em push para `main`, com `release_eligible=true` e sucesso dos jobs obrigatorios.
 
+### Governanca de churn documental
+
+- O guardrail `verify:enterprise-focus` bloqueia o `CI` pelo delta do evento atual, nunca por ruído acumulado da branch principal.
+- Em `pull_request`, a comparacao usa `base.sha...head.sha`.
+- Em `push`, a comparacao usa `before..after`, com fallback para o commit atual quando o push cria a referencia.
+- A janela historica de 50 commits continua existindo apenas como telemetria e pode gerar `WARN`, mas nao deve bloquear merges validos por churn documental preexistente.
+
 ## Fluxo do `Release`
 
 1. `validate-ci-status` confirma um run bem-sucedido do `CI` para o mesmo commit.

--- a/scripts/verify-enterprise-focus.sh
+++ b/scripts/verify-enterprise-focus.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Guardrail operacional para evitar regressão de foco/churn/fragmentação.
 # Author: Fillipe Guerra
-# Data: 10 de Março de 2026
+# Data: 18 de Março de 2026
 
 WINDOW="${1:-200}"
 ENFORCE_FAILURE="${ENFORCE_FAILURE:-false}"
@@ -31,19 +31,151 @@ if (( total_commits_available == 0 )); then
   exit 2
 fi
 
-if (( total_commits_available <= WINDOW )); then
-  RANGE="HEAD"
-else
-  RANGE="HEAD~${WINDOW}..HEAD"
+resolve_historical_range() {
+  if (( total_commits_available <= WINDOW )); then
+    printf 'HEAD'
+    return
+  fi
+
+  printf 'HEAD~%s..HEAD' "$WINDOW"
+}
+
+is_valid_commit_ref() {
+  local ref="$1"
+  [[ -n "$ref" ]] && git cat-file -e "${ref}^{commit}" >/dev/null 2>&1
+}
+
+resolve_event_range() {
+  if [[ -n "${ALICE_ENTERPRISE_FOCUS_BASE_SHA:-}" && -n "${ALICE_ENTERPRISE_FOCUS_HEAD_SHA:-}" ]]; then
+    local explicit_mode="${ALICE_ENTERPRISE_FOCUS_DIFF_MODE:-double_dot}"
+    printf '%s\n%s\n%s\n%s\n' \
+      "${ALICE_ENTERPRISE_FOCUS_BASE_SHA}" \
+      "${ALICE_ENTERPRISE_FOCUS_HEAD_SHA}" \
+      "${explicit_mode}" \
+      'range_explicit'
+    return
+  fi
+
+  if [[ -z "${GITHUB_EVENT_NAME:-}" || -z "${GITHUB_EVENT_PATH:-}" || ! -f "${GITHUB_EVENT_PATH}" ]]; then
+    return
+  fi
+
+  local parsed_range
+  parsed_range="$(
+    node <<'NODE'
+const fs = require('fs');
+
+const eventPath = process.env.GITHUB_EVENT_PATH;
+const eventName = process.env.GITHUB_EVENT_NAME ?? '';
+
+if (!eventPath || !fs.existsSync(eventPath)) {
+  process.exit(0);
+}
+
+const event = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+let baseSha = '';
+let headSha = '';
+let diffMode = '';
+let source = '';
+
+if (eventName === 'push') {
+  baseSha = typeof event.before === 'string' ? event.before : '';
+  headSha = typeof event.after === 'string' ? event.after : (process.env.GITHUB_SHA ?? '');
+  diffMode = /^0+$/.test(baseSha) ? 'single_commit' : 'double_dot';
+  source = 'github_push';
+} else if (eventName.startsWith('pull_request')) {
+  baseSha = event.pull_request?.base?.sha ?? '';
+  headSha = event.pull_request?.head?.sha ?? (process.env.GITHUB_SHA ?? '');
+  diffMode = 'triple_dot';
+  source = 'github_pull_request';
+}
+
+if (!baseSha || !headSha) {
+  process.exit(0);
+}
+
+process.stdout.write(`${baseSha}\n${headSha}\n${diffMode}\n${source}`);
+NODE
+  )"
+
+  if [[ -z "${parsed_range}" ]]; then
+    return
+  fi
+
+  printf '%s\n' "${parsed_range}"
+}
+
+count_changed_paths() {
+  local base_ref="$1"
+  local head_ref="$2"
+  local diff_mode="$3"
+
+  case "$diff_mode" in
+    triple_dot)
+      git diff --name-only "${base_ref}...${head_ref}" | sed '/^$/d'
+      ;;
+    single_commit)
+      git show --pretty=format: --name-only "${head_ref}" | sed '/^$/d'
+      ;;
+    *)
+      git diff --name-only "${base_ref}..${head_ref}" | sed '/^$/d'
+      ;;
+  esac
+}
+
+count_commits_in_range() {
+  local base_ref="$1"
+  local head_ref="$2"
+  local diff_mode="$3"
+
+  case "$diff_mode" in
+    single_commit)
+      printf '1'
+      ;;
+    *)
+      git rev-list --count "${base_ref}..${head_ref}" | tr -d ' '
+      ;;
+  esac
+}
+
+HISTORICAL_RANGE="$(resolve_historical_range)"
+RANGE="$HISTORICAL_RANGE"
+ANALYSIS_SOURCE='historical_window'
+DOC_CHURN_LABEL='Churn documental'
+HISTORICAL_ONLY_NOTE=''
+
+event_range=()
+while IFS= read -r line; do
+  event_range+=("$line")
+done < <(resolve_event_range || true)
+
+if (( ${#event_range[@]} == 4 )) && is_valid_commit_ref "${event_range[1]}"; then
+  if [[ "${event_range[2]}" == 'single_commit' ]] || is_valid_commit_ref "${event_range[0]}"; then
+    RANGE="${event_range[0]}..${event_range[1]}"
+    ANALYSIS_SOURCE="${event_range[3]}"
+    DOC_CHURN_LABEL='Churn documental (delta atual)'
+    HISTORICAL_ONLY_NOTE='Churn documental histórico (telemetria)'
+    touches_total="$(count_changed_paths "${event_range[0]}" "${event_range[1]}" "${event_range[2]}" | wc -l | tr -d ' ')"
+    doc_touches="$(count_changed_paths "${event_range[0]}" "${event_range[1]}" "${event_range[2]}" | grep -E '^(docs/|README\.md$)' || true)"
+    doc_touches="$(printf '%s\n' "$doc_touches" | sed '/^$/d' | wc -l | tr -d ' ')"
+    commits_total="$(count_commits_in_range "${event_range[0]}" "${event_range[1]}" "${event_range[2]}")"
+    wise_commit_mentions="$(git log --pretty=format:%s "${event_range[0]}..${event_range[1]}" | grep -Ei 'wise' || true)"
+    wise_commit_mentions="$(printf '%s\n' "$wise_commit_mentions" | sed '/^$/d' | wc -l | tr -d ' ')"
+  fi
 fi
 
-commits_total="$(git log --pretty=format:%s "$RANGE" | sed '/^$/d' | wc -l | tr -d ' ')"
-touches_total="$(git log --name-only --pretty=format: "$RANGE" | sed '/^$/d' | wc -l | tr -d ' ')"
-doc_touches="$(git log --name-only --pretty=format: "$RANGE" | sed '/^$/d' | grep -E '^(docs/|README\.md$)' || true)"
-doc_touches="$(printf '%s\n' "$doc_touches" | sed '/^$/d' | wc -l | tr -d ' ')"
+if [[ "${ANALYSIS_SOURCE}" == 'historical_window' ]]; then
+  commits_total="$(git log --pretty=format:%s "$RANGE" | sed '/^$/d' | wc -l | tr -d ' ')"
+  touches_total="$(git log --name-only --pretty=format: "$RANGE" | sed '/^$/d' | wc -l | tr -d ' ')"
+  doc_touches="$(git log --name-only --pretty=format: "$RANGE" | sed '/^$/d' | grep -E '^(docs/|README\.md$)' || true)"
+  doc_touches="$(printf '%s\n' "$doc_touches" | sed '/^$/d' | wc -l | tr -d ' ')"
+  wise_commit_mentions="$(git log --pretty=format:%s "$RANGE" | grep -Ei 'wise' || true)"
+  wise_commit_mentions="$(printf '%s\n' "$wise_commit_mentions" | sed '/^$/d' | wc -l | tr -d ' ')"
+fi
 
-wise_commit_mentions="$(git log --pretty=format:%s "$RANGE" | grep -Ei 'wise' || true)"
-wise_commit_mentions="$(printf '%s\n' "$wise_commit_mentions" | sed '/^$/d' | wc -l | tr -d ' ')"
+historical_touches_total="$(git log --name-only --pretty=format: "$HISTORICAL_RANGE" | sed '/^$/d' | wc -l | tr -d ' ')"
+historical_doc_touches="$(git log --name-only --pretty=format: "$HISTORICAL_RANGE" | sed '/^$/d' | grep -E '^(docs/|README\.md$)' || true)"
+historical_doc_touches="$(printf '%s\n' "$historical_doc_touches" | sed '/^$/d' | wc -l | tr -d ' ')"
 
 wise_files="$(find apps/frontend-service/src/pages/wise-payments -type f \( -name '*.ts' -o -name '*.tsx' \) | wc -l | tr -d ' ')"
 wise_loc="$(find apps/frontend-service/src/pages/wise-payments -type f \( -name '*.ts' -o -name '*.tsx' \) -print0 | xargs -0 wc -l | tail -n 1 | awk '{print $1}')"
@@ -61,10 +193,20 @@ if (( commits_total > 0 )); then
   wise_commit_pct="$(awk "BEGIN { printf \"%.2f\", (${wise_commit_mentions} * 100) / ${commits_total} }")"
 fi
 
-echo "Janela analisada: ${RANGE}"
-echo "Commits na janela: ${commits_total}"
+historical_doc_touch_pct="0"
+if (( historical_touches_total > 0 )); then
+  historical_doc_touch_pct="$(awk "BEGIN { printf \"%.2f\", (${historical_doc_touches} * 100) / ${historical_touches_total} }")"
+fi
+
+echo "Modo de análise: ${ANALYSIS_SOURCE}"
+echo "Range principal: ${RANGE}"
+echo "Commits no range principal: ${commits_total}"
 echo "Touches totais: ${touches_total}"
 echo "Touches docs+README: ${doc_touches} (${doc_touch_pct}%)"
+if [[ -n "${HISTORICAL_ONLY_NOTE}" ]]; then
+  echo "Range histórico auxiliar: ${HISTORICAL_RANGE}"
+  echo "Touches docs+README histórico: ${historical_doc_touches} (${historical_doc_touch_pct}%)"
+fi
 echo "Commits com foco Wise: ${wise_commit_mentions} (${wise_commit_pct}%)"
 echo "Wise files (TS/TSX): ${wise_files}"
 echo "Wise LOC (TS/TSX): ${wise_loc}"
@@ -97,12 +239,20 @@ check_lte() {
   fi
 }
 
-check_pct_lte "$doc_touch_pct" "$DOC_TOUCH_THRESHOLD_PCT" "Churn documental"
+check_pct_lte "$doc_touch_pct" "$DOC_TOUCH_THRESHOLD_PCT" "$DOC_CHURN_LABEL"
 check_pct_lte "$wise_commit_pct" "$WISE_COMMIT_THRESHOLD_PCT" "Foco desbalanceado no domínio Wise"
 check_lte "$wise_files" "$WISE_FILES_THRESHOLD" "Fragmentação de arquivos Wise"
 check_lte "$wise_loc" "$WISE_LOC_THRESHOLD" "Densidade total Wise"
 check_lte "$trading_content_lines" "$TRADING_CONTENT_LINES_THRESHOLD" "Densidade TradingContent"
 check_lte "$chat_layout_controller_lines" "$CHAT_LAYOUT_CONTROLLER_LINES_THRESHOLD" "Densidade Chat layout controller"
+
+if [[ -n "${HISTORICAL_ONLY_NOTE}" ]]; then
+  if awk "BEGIN { exit !(${historical_doc_touch_pct} <= ${DOC_TOUCH_THRESHOLD_PCT}) }"; then
+    echo "OK   - ${HISTORICAL_ONLY_NOTE}: ${historical_doc_touch_pct}% <= ${DOC_TOUCH_THRESHOLD_PCT}%"
+  else
+    echo "WARN - ${HISTORICAL_ONLY_NOTE}: ${historical_doc_touch_pct}% > ${DOC_TOUCH_THRESHOLD_PCT}%"
+  fi
+fi
 
 if (( failed != 0 )); then
   if [[ "${ENFORCE_FAILURE}" == "true" ]]; then

--- a/scripts/verify-enterprise-focus.sh
+++ b/scripts/verify-enterprise-focus.sh
@@ -129,6 +129,9 @@ count_commits_in_range() {
   local diff_mode="$3"
 
   case "$diff_mode" in
+    triple_dot)
+      git rev-list --right-only --count "${base_ref}...${head_ref}" | tr -d ' '
+      ;;
     single_commit)
       printf '1'
       ;;
@@ -143,18 +146,21 @@ count_commit_subject_matches() {
   local head_ref="$2"
   local diff_mode="$3"
   local pattern="$4"
+  local commit_subjects=''
 
   case "$diff_mode" in
     triple_dot)
-      git log --pretty=format:%s "${base_ref}...${head_ref}" | grep -Ei -- "$pattern" || true
+      commit_subjects="$(git log --right-only --pretty=format:%s "${base_ref}...${head_ref}" || true)"
       ;;
     single_commit)
-      git log --pretty=format:%s -n 1 "${head_ref}" | grep -Ei -- "$pattern" || true
+      commit_subjects="$(git log --pretty=format:%s -n 1 "${head_ref}" || true)"
       ;;
     *)
-      git log --pretty=format:%s "${base_ref}..${head_ref}" | grep -Ei -- "$pattern" || true
+      commit_subjects="$(git log --pretty=format:%s "${base_ref}..${head_ref}" || true)"
       ;;
   esac
+
+  printf '%s\n' "${commit_subjects}" | grep -Ei -- "$pattern" || true
 }
 
 HISTORICAL_RANGE="$(resolve_historical_range)"

--- a/scripts/verify-enterprise-focus.sh
+++ b/scripts/verify-enterprise-focus.sh
@@ -138,6 +138,25 @@ count_commits_in_range() {
   esac
 }
 
+count_commit_subject_matches() {
+  local base_ref="$1"
+  local head_ref="$2"
+  local diff_mode="$3"
+  local pattern="$4"
+
+  case "$diff_mode" in
+    triple_dot)
+      git log --pretty=format:%s "${base_ref}...${head_ref}" | grep -Ei -- "$pattern" || true
+      ;;
+    single_commit)
+      git log --pretty=format:%s -n 1 "${head_ref}" | grep -Ei -- "$pattern" || true
+      ;;
+    *)
+      git log --pretty=format:%s "${base_ref}..${head_ref}" | grep -Ei -- "$pattern" || true
+      ;;
+  esac
+}
+
 HISTORICAL_RANGE="$(resolve_historical_range)"
 RANGE="$HISTORICAL_RANGE"
 ANALYSIS_SOURCE='historical_window'
@@ -159,7 +178,7 @@ if (( ${#event_range[@]} == 4 )) && is_valid_commit_ref "${event_range[1]}"; the
     doc_touches="$(count_changed_paths "${event_range[0]}" "${event_range[1]}" "${event_range[2]}" | grep -E '^(docs/|README\.md$)' || true)"
     doc_touches="$(printf '%s\n' "$doc_touches" | sed '/^$/d' | wc -l | tr -d ' ')"
     commits_total="$(count_commits_in_range "${event_range[0]}" "${event_range[1]}" "${event_range[2]}")"
-    wise_commit_mentions="$(git log --pretty=format:%s "${event_range[0]}..${event_range[1]}" | grep -Ei 'wise' || true)"
+    wise_commit_mentions="$(count_commit_subject_matches "${event_range[0]}" "${event_range[1]}" "${event_range[2]}" 'wise')"
     wise_commit_mentions="$(printf '%s\n' "$wise_commit_mentions" | sed '/^$/d' | wc -l | tr -d ' ')"
   fi
 fi

--- a/tests/e2e/backup-restore-game-day.test.ts
+++ b/tests/e2e/backup-restore-game-day.test.ts
@@ -8,9 +8,9 @@ function read(relativePath: string): string {
 
 describe('backup restore game day guards', () => {
   it('keeps DR runbook with explicit RTO/RPO targets', () => {
-    const runbook = read('docs/DR-RUNBOOK.md');
-    expect(runbook.includes('RTO alvo')).toBe(true);
-    expect(runbook.includes('RPO alvo')).toBe(true);
+    const runbook = read('docs/operations/runbooks/dr-game-day.md');
+    expect(runbook.includes('`RTO` alvo')).toBe(true);
+    expect(runbook.includes('`RPO` alvo')).toBe(true);
     expect(runbook.includes('Game Day')).toBe(true);
   });
 

--- a/tests/integration/enterprise-ops-validation-guards.test.ts
+++ b/tests/integration/enterprise-ops-validation-guards.test.ts
@@ -14,9 +14,9 @@ describe('enterprise ops validation guards', () => {
   });
 
   it('keeps runbooks for DR, training GPU validation and SLO burn-rate', () => {
-    const drRunbook = read('docs/DR-RUNBOOK.md');
-    const gpuRunbook = read('docs/TRAINING-GPU-VALIDATION-RUNBOOK.md');
-    const sloRunbook = read('docs/SLO-BURN-RATE-RUNBOOK.md');
+    const drRunbook = read('docs/operations/runbooks/dr-game-day.md');
+    const gpuRunbook = read('docs/operations/runbooks/training-gpu-validation.md');
+    const sloRunbook = read('docs/operations/runbooks/slo-burn-rate-validation.md');
 
     expect(drRunbook.includes('run-dr-game-day.sh')).toBe(true);
     expect(gpuRunbook.includes('validate-gpu-fine-tuning.sh')).toBe(true);

--- a/tests/unit/enterprise-focus-governance.test.ts
+++ b/tests/unit/enterprise-focus-governance.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function loadEnterpriseFocusScript(): string {
+  return readFileSync(path.join(process.cwd(), 'scripts/verify-enterprise-focus.sh'), 'utf-8');
+}
+
+describe('enterprise focus governance script', () => {
+  it('prioritizes the current event delta when CI provides GitHub context', () => {
+    const source = loadEnterpriseFocusScript();
+
+    expect(source.includes('GITHUB_EVENT_NAME')).toBe(true);
+    expect(source.includes('GITHUB_EVENT_PATH')).toBe(true);
+    expect(source.includes("DOC_CHURN_LABEL='Churn documental (delta atual)'")).toBe(true);
+    expect(source.includes("source = 'github_push'")).toBe(true);
+    expect(source.includes("source = 'github_pull_request'")).toBe(true);
+  });
+
+  it('supports explicit base and head overrides for deterministic local validation', () => {
+    const source = loadEnterpriseFocusScript();
+
+    expect(source.includes('ALICE_ENTERPRISE_FOCUS_BASE_SHA')).toBe(true);
+    expect(source.includes('ALICE_ENTERPRISE_FOCUS_HEAD_SHA')).toBe(true);
+    expect(source.includes('ALICE_ENTERPRISE_FOCUS_DIFF_MODE')).toBe(true);
+  });
+
+  it('keeps the historical 50-commit window only as non-blocking telemetry', () => {
+    const source = loadEnterpriseFocusScript();
+
+    expect(source.includes("HISTORICAL_ONLY_NOTE='Churn documental histórico (telemetria)'")).toBe(true);
+    expect(source.includes('WARN - ${HISTORICAL_ONLY_NOTE}')).toBe(true);
+    expect(source.includes('Resultado: WARN (há regressões históricas; monitoramento sem bloqueio nesta execução).')).toBe(true);
+  });
+});

--- a/tests/unit/enterprise-focus-governance.test.ts
+++ b/tests/unit/enterprise-focus-governance.test.ts
@@ -1,14 +1,56 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
 
-function loadEnterpriseFocusScript(): string {
-  return readFileSync(path.join(process.cwd(), 'scripts/verify-enterprise-focus.sh'), 'utf-8');
+const SCRIPT_PATH = path.join(process.cwd(), 'scripts/verify-enterprise-focus.sh');
+
+function createGovernanceFixture(): {
+  cleanup: () => void;
+  repoDir: string;
+  headSha: string;
+} {
+  const repoDir = mkdtempSync(path.join(tmpdir(), 'alice-governance-'));
+
+  mkdirSync(path.join(repoDir, 'scripts'), { recursive: true });
+  mkdirSync(path.join(repoDir, 'apps/frontend-service/src/pages/wise-payments'), { recursive: true });
+  mkdirSync(path.join(repoDir, 'apps/frontend-service/src/pages/Chat'), { recursive: true });
+  mkdirSync(path.join(repoDir, 'docs/engineering'), { recursive: true });
+
+  writeFileSync(path.join(repoDir, 'scripts/verify-enterprise-focus.sh'), readFileSync(SCRIPT_PATH, 'utf-8'));
+  writeFileSync(path.join(repoDir, 'apps/frontend-service/src/pages/wise-payments/index.tsx'), 'export const wise = true;\n');
+  writeFileSync(path.join(repoDir, 'apps/frontend-service/src/pages/TradingContent.tsx'), 'export const trading = true;\n');
+  writeFileSync(
+    path.join(repoDir, 'apps/frontend-service/src/pages/Chat/useChatPageLayoutController.ts'),
+    'export const controller = true;\n',
+  );
+  writeFileSync(path.join(repoDir, 'docs/engineering/pipeline-overview.md'), '# Pipeline\n');
+  writeFileSync(path.join(repoDir, 'README.md'), '# Alice\n');
+  writeFileSync(path.join(repoDir, 'feature.ts'), 'export const feature = 1;\n');
+
+  execFileSync('git', ['init', '-b', 'main'], { cwd: repoDir });
+  execFileSync('git', ['config', 'user.name', 'Codex'], { cwd: repoDir });
+  execFileSync('git', ['config', 'user.email', 'codex@example.com'], { cwd: repoDir });
+  execFileSync('git', ['add', '.'], { cwd: repoDir });
+  execFileSync('git', ['commit', '-m', 'chore: seed governance fixture'], { cwd: repoDir });
+
+  writeFileSync(path.join(repoDir, 'feature.ts'), 'export const feature = 2;\n');
+  execFileSync('git', ['add', 'feature.ts'], { cwd: repoDir });
+  execFileSync('git', ['commit', '-m', 'Wise: single commit governance coverage'], { cwd: repoDir });
+
+  const headSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repoDir, encoding: 'utf-8' }).trim();
+
+  return {
+    cleanup: () => rmSync(repoDir, { recursive: true, force: true }),
+    repoDir,
+    headSha,
+  };
 }
 
 describe('enterprise focus governance script', () => {
   it('prioritizes the current event delta when CI provides GitHub context', () => {
-    const source = loadEnterpriseFocusScript();
+    const source = readFileSync(SCRIPT_PATH, 'utf-8');
 
     expect(source.includes('GITHUB_EVENT_NAME')).toBe(true);
     expect(source.includes('GITHUB_EVENT_PATH')).toBe(true);
@@ -18,7 +60,7 @@ describe('enterprise focus governance script', () => {
   });
 
   it('supports explicit base and head overrides for deterministic local validation', () => {
-    const source = loadEnterpriseFocusScript();
+    const source = readFileSync(SCRIPT_PATH, 'utf-8');
 
     expect(source.includes('ALICE_ENTERPRISE_FOCUS_BASE_SHA')).toBe(true);
     expect(source.includes('ALICE_ENTERPRISE_FOCUS_HEAD_SHA')).toBe(true);
@@ -26,10 +68,38 @@ describe('enterprise focus governance script', () => {
   });
 
   it('keeps the historical 50-commit window only as non-blocking telemetry', () => {
-    const source = loadEnterpriseFocusScript();
+    const source = readFileSync(SCRIPT_PATH, 'utf-8');
 
     expect(source.includes("HISTORICAL_ONLY_NOTE='Churn documental histórico (telemetria)'")).toBe(true);
     expect(source.includes('WARN - ${HISTORICAL_ONLY_NOTE}')).toBe(true);
     expect(source.includes('Resultado: WARN (há regressões históricas; monitoramento sem bloqueio nesta execução).')).toBe(true);
+  });
+
+  it('counts Wise mentions correctly when the event delta is a single commit', () => {
+    const fixture = createGovernanceFixture();
+
+    try {
+      const result = spawnSync('bash', ['scripts/verify-enterprise-focus.sh', '50'], {
+        cwd: fixture.repoDir,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          ALICE_ENTERPRISE_FOCUS_BASE_SHA: '0000000000000000000000000000000000000000',
+          ALICE_ENTERPRISE_FOCUS_HEAD_SHA: fixture.headSha,
+          ALICE_ENTERPRISE_FOCUS_DIFF_MODE: 'single_commit',
+          DOC_TOUCH_THRESHOLD_PCT: '100',
+          WISE_COMMIT_THRESHOLD_PCT: '0',
+          ENFORCE_FAILURE: 'true',
+        },
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('Modo de análise: range_explicit');
+      expect(result.stdout).toContain('Commits no range principal: 1');
+      expect(result.stdout).toContain('Commits com foco Wise: 1 (100.00%)');
+      expect(result.stdout).toContain('FAIL - Foco desbalanceado no domínio Wise: 100.00% > 0%');
+    } finally {
+      fixture.cleanup();
+    }
   });
 });

--- a/tests/unit/enterprise-focus-governance.test.ts
+++ b/tests/unit/enterprise-focus-governance.test.ts
@@ -29,21 +29,73 @@ function createGovernanceFixture(): {
   writeFileSync(path.join(repoDir, 'README.md'), '# Alice\n');
   writeFileSync(path.join(repoDir, 'feature.ts'), 'export const feature = 1;\n');
 
-  execFileSync('git', ['init', '-b', 'main'], { cwd: repoDir });
+  execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: repoDir });
   execFileSync('git', ['config', 'user.name', 'Codex'], { cwd: repoDir });
   execFileSync('git', ['config', 'user.email', 'codex@example.com'], { cwd: repoDir });
   execFileSync('git', ['add', '.'], { cwd: repoDir });
-  execFileSync('git', ['commit', '-m', 'chore: seed governance fixture'], { cwd: repoDir });
+  execFileSync('git', ['commit', '--quiet', '-m', 'chore: seed governance fixture'], { cwd: repoDir });
 
   writeFileSync(path.join(repoDir, 'feature.ts'), 'export const feature = 2;\n');
   execFileSync('git', ['add', 'feature.ts'], { cwd: repoDir });
-  execFileSync('git', ['commit', '-m', 'Wise: single commit governance coverage'], { cwd: repoDir });
+  execFileSync('git', ['commit', '--quiet', '-m', 'Wise: single commit governance coverage'], { cwd: repoDir });
 
   const headSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repoDir, encoding: 'utf-8' }).trim();
 
   return {
     cleanup: () => rmSync(repoDir, { recursive: true, force: true }),
     repoDir,
+    headSha,
+  };
+}
+
+function createPullRequestGovernanceFixture(): {
+  cleanup: () => void;
+  repoDir: string;
+  baseSha: string;
+  headSha: string;
+} {
+  const repoDir = mkdtempSync(path.join(tmpdir(), 'alice-governance-pr-'));
+
+  mkdirSync(path.join(repoDir, 'scripts'), { recursive: true });
+  mkdirSync(path.join(repoDir, 'apps/frontend-service/src/pages/wise-payments'), { recursive: true });
+  mkdirSync(path.join(repoDir, 'apps/frontend-service/src/pages/Chat'), { recursive: true });
+  mkdirSync(path.join(repoDir, 'docs/engineering'), { recursive: true });
+
+  writeFileSync(path.join(repoDir, 'scripts/verify-enterprise-focus.sh'), readFileSync(SCRIPT_PATH, 'utf-8'));
+  writeFileSync(path.join(repoDir, 'apps/frontend-service/src/pages/wise-payments/index.tsx'), 'export const wise = true;\n');
+  writeFileSync(path.join(repoDir, 'apps/frontend-service/src/pages/TradingContent.tsx'), 'export const trading = true;\n');
+  writeFileSync(
+    path.join(repoDir, 'apps/frontend-service/src/pages/Chat/useChatPageLayoutController.ts'),
+    'export const controller = true;\n',
+  );
+  writeFileSync(path.join(repoDir, 'docs/engineering/pipeline-overview.md'), '# Pipeline\n');
+  writeFileSync(path.join(repoDir, 'README.md'), '# Alice\n');
+  writeFileSync(path.join(repoDir, 'feature.ts'), 'export const feature = 1;\n');
+
+  execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: repoDir });
+  execFileSync('git', ['config', 'user.name', 'Codex'], { cwd: repoDir });
+  execFileSync('git', ['config', 'user.email', 'codex@example.com'], { cwd: repoDir });
+  execFileSync('git', ['add', '.'], { cwd: repoDir });
+  execFileSync('git', ['commit', '--quiet', '-m', 'chore: seed governance fixture'], { cwd: repoDir });
+
+  execFileSync('git', ['checkout', '--quiet', '-b', 'feature/governance-scope'], { cwd: repoDir });
+  writeFileSync(path.join(repoDir, 'feature.ts'), 'export const feature = 2;\n');
+  execFileSync('git', ['add', 'feature.ts'], { cwd: repoDir });
+  execFileSync('git', ['commit', '--quiet', '-m', 'feat: branch-specific governance coverage'], { cwd: repoDir });
+
+  const headSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repoDir, encoding: 'utf-8' }).trim();
+
+  execFileSync('git', ['checkout', '--quiet', 'main'], { cwd: repoDir });
+  writeFileSync(path.join(repoDir, 'README.md'), '# Alice Wise Base\n');
+  execFileSync('git', ['add', 'README.md'], { cwd: repoDir });
+  execFileSync('git', ['commit', '--quiet', '-m', 'Wise: base branch only commit'], { cwd: repoDir });
+
+  const baseSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repoDir, encoding: 'utf-8' }).trim();
+
+  return {
+    cleanup: () => rmSync(repoDir, { recursive: true, force: true }),
+    repoDir,
+    baseSha,
     headSha,
   };
 }
@@ -98,6 +150,34 @@ describe('enterprise focus governance script', () => {
       expect(result.stdout).toContain('Commits no range principal: 1');
       expect(result.stdout).toContain('Commits com foco Wise: 1 (100.00%)');
       expect(result.stdout).toContain('FAIL - Foco desbalanceado no domínio Wise: 100.00% > 0%');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('keeps pull request commit matching restricted to head-side commits only', () => {
+    const fixture = createPullRequestGovernanceFixture();
+
+    try {
+      const result = spawnSync('bash', ['scripts/verify-enterprise-focus.sh', '50'], {
+        cwd: fixture.repoDir,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          ALICE_ENTERPRISE_FOCUS_BASE_SHA: fixture.baseSha,
+          ALICE_ENTERPRISE_FOCUS_HEAD_SHA: fixture.headSha,
+          ALICE_ENTERPRISE_FOCUS_DIFF_MODE: 'triple_dot',
+          DOC_TOUCH_THRESHOLD_PCT: '100',
+          WISE_COMMIT_THRESHOLD_PCT: '0',
+          ENFORCE_FAILURE: 'true',
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Modo de análise: range_explicit');
+      expect(result.stdout).toContain('Commits no range principal: 1');
+      expect(result.stdout).toContain('Commits com foco Wise: 0 (0.00%)');
+      expect(result.stdout).toContain('OK   - Foco desbalanceado no domínio Wise: 0.00% <= 0%');
     } finally {
       fixture.cleanup();
     }


### PR DESCRIPTION
## Summary
- make enterprise focus governance block on the current PR/push delta instead of the trailing 50-commit window
- keep the historical 50-commit documentation churn as telemetry-only warning
- align DR and ops validation guard tests with the canonical runbook paths

## Validation
- pnpm typecheck
- pnpm test
- pnpm lint
- pnpm build
- ENFORCE_FAILURE=true bash ./scripts/verify-enterprise-focus.sh 50 with explicit base/head range

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the `verify:enterprise-focus` guardrail logic that can block CI runs, so mis-parsing GitHub event ranges could cause unexpected CI failures or missed governance violations. Changes are localized to CI governance scripting and associated tests/docs.
> 
> **Overview**
> **Enterprise governance checks now key off the current GitHub event delta** instead of the trailing N-commit window. `scripts/verify-enterprise-focus.sh` resolves a base/head range from GitHub event payload (or explicit `ALICE_ENTERPRISE_FOCUS_*` overrides), supports `push` vs `pull_request` diff modes (`..`, `...`, single-commit), and only *warns* on historical 50-commit doc churn while enforcing thresholds on the current delta.
> 
> Documentation and tests were aligned with this behavior: `docs/engineering/pipeline-overview.md` documents the new churn governance rules, runbook guard tests now reference the canonical `docs/operations/runbooks/*` paths, and a new unit suite (`tests/unit/enterprise-focus-governance.test.ts`) covers the range-resolution and counting behavior (including single-commit and PR head-only semantics).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72105b1b505b96a3de98e8604b9a600a63b2a271. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->